### PR TITLE
DNS Manager only shows first 7 chars of long usernames

### DIFF
--- a/godaddy-ddns.php
+++ b/godaddy-ddns.php
@@ -215,7 +215,7 @@ class GoDaddyDNS
      */
     public function isLoggedIn($username) {
         if (preg_match('#Welcome:&nbsp;<span id="ctl00_lblUser" .*?\>(.*)</span>#', $this->_lastResponse, $match)) {
-            if (strtolower($match[1]) == strtolower($username) || $match[2] == $username) {
+            if (substr(strtolower($match[1]),0,7) == substr(strtolower($username),0,7) || $match[2] == $username) {
                 return true;
             } else {
                 // An unexpected user was logged in


### PR DESCRIPTION
isLoggedIn check would fail if the user has a username longer than 7
characters. The interface shortens the welcome message to:
  "Welcome: usernam..."

This change makes the isLoggedIn test based on the first 7 characters of
the username and the regex matched string.
